### PR TITLE
feat(lender): add `lend` implementation

### DIFF
--- a/src/constants/abi/lender-abi.ts
+++ b/src/constants/abi/lender-abi.ts
@@ -1,10 +1,721 @@
 export const LENDER_ABI = [
-    'function admin() public view returns(address)',
-    'function marketPlace() public view returns(address)',
-    'function swivelAddr() public view returns(address)',
-    'function pendleAddr() public view returns(address)',
-    'function tempusAddr() public view returns(address)',
-    'function feenominator() public view returns(uint256)',
-    'function fees(address address) public view returns(uint256)',
-    'function mint(uint8 principal, address underlying, uint256 maturity, uint256 amount) public returns (bool)',
+    {
+        'inputs': [
+            {
+                'internalType': 'address',
+                'name': 's',
+                'type': 'address',
+            },
+            {
+                'internalType': 'address',
+                'name': 'p',
+                'type': 'address',
+            },
+            {
+                'internalType': 'address',
+                'name': 't',
+                'type': 'address',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'constructor',
+    },
+    {
+        'anonymous': false,
+        'inputs': [
+            {
+                'indexed': false,
+                'internalType': 'uint8',
+                'name': 'principal',
+                'type': 'uint8',
+            },
+            {
+                'indexed': true,
+                'internalType': 'address',
+                'name': 'underlying',
+                'type': 'address',
+            },
+            {
+                'indexed': true,
+                'internalType': 'uint256',
+                'name': 'maturity',
+                'type': 'uint256',
+            },
+            {
+                'indexed': false,
+                'internalType': 'uint256',
+                'name': 'returned',
+                'type': 'uint256',
+            },
+        ],
+        'name': 'Lend',
+        'type': 'event',
+    },
+    {
+        'anonymous': false,
+        'inputs': [
+            {
+                'indexed': false,
+                'internalType': 'uint8',
+                'name': 'principal',
+                'type': 'uint8',
+            },
+            {
+                'indexed': true,
+                'internalType': 'address',
+                'name': 'underlying',
+                'type': 'address',
+            },
+            {
+                'indexed': true,
+                'internalType': 'uint256',
+                'name': 'maturity',
+                'type': 'uint256',
+            },
+            {
+                'indexed': false,
+                'internalType': 'uint256',
+                'name': 'amount',
+                'type': 'uint256',
+            },
+        ],
+        'name': 'Mint',
+        'type': 'event',
+    },
+    {
+        'inputs': [
+
+        ],
+        'name': 'admin',
+        'outputs': [
+            {
+                'internalType': 'address',
+                'name': '',
+                'type': 'address',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+
+        ],
+        'name': 'feenominator',
+        'outputs': [
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'address',
+                'name': '',
+                'type': 'address',
+            },
+        ],
+        'name': 'fees',
+        'outputs': [
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'uint8',
+                'name': 'p',
+                'type': 'uint8',
+            },
+            {
+                'internalType': 'address',
+                'name': 'u',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'm',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'a',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'r',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'd',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'address',
+                'name': 'e',
+                'type': 'address',
+            },
+            {
+                'internalType': 'bytes32',
+                'name': 'i',
+                'type': 'bytes32',
+            },
+        ],
+        'name': 'lend',
+        'outputs': [
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'uint8',
+                'name': 'p',
+                'type': 'uint8',
+            },
+            {
+                'internalType': 'address',
+                'name': 'u',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'm',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'a',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'r',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'address',
+                'name': 'pool',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'i',
+                'type': 'uint256',
+            },
+        ],
+        'name': 'lend',
+        'outputs': [
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'uint8',
+                'name': 'p',
+                'type': 'uint8',
+            },
+            {
+                'internalType': 'address',
+                'name': 'u',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'm',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'a',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'r',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'd',
+                'type': 'uint256',
+            },
+        ],
+        'name': 'lend',
+        'outputs': [
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'uint8',
+                'name': 'p',
+                'type': 'uint8',
+            },
+            {
+                'internalType': 'address',
+                'name': 'u',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'm',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint128',
+                'name': 'a',
+                'type': 'uint128',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'r',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'address',
+                'name': 'x',
+                'type': 'address',
+            },
+            {
+                'internalType': 'address',
+                'name': 's',
+                'type': 'address',
+            },
+        ],
+        'name': 'lend',
+        'outputs': [
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'uint8',
+                'name': 'p',
+                'type': 'uint8',
+            },
+            {
+                'internalType': 'address',
+                'name': 'u',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'm',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'a',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'r',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'd',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'address',
+                'name': 't',
+                'type': 'address',
+            },
+            {
+                'internalType': 'address',
+                'name': 'x',
+                'type': 'address',
+            },
+        ],
+        'name': 'lend',
+        'outputs': [
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'uint8',
+                'name': 'p',
+                'type': 'uint8',
+            },
+            {
+                'internalType': 'address',
+                'name': 'u',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'm',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'a',
+                'type': 'uint256',
+            },
+        ],
+        'name': 'lend',
+        'outputs': [
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'uint8',
+                'name': 'p',
+                'type': 'uint8',
+            },
+            {
+                'internalType': 'address',
+                'name': 'u',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'm',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256[]',
+                'name': 'a',
+                'type': 'uint256[]',
+            },
+            {
+                'internalType': 'address',
+                'name': 'y',
+                'type': 'address',
+            },
+            {
+                'components': [
+                    {
+                        'internalType': 'bytes32',
+                        'name': 'key',
+                        'type': 'bytes32',
+                    },
+                    {
+                        'internalType': 'address',
+                        'name': 'maker',
+                        'type': 'address',
+                    },
+                    {
+                        'internalType': 'address',
+                        'name': 'underlying',
+                        'type': 'address',
+                    },
+                    {
+                        'internalType': 'bool',
+                        'name': 'vault',
+                        'type': 'bool',
+                    },
+                    {
+                        'internalType': 'bool',
+                        'name': 'exit',
+                        'type': 'bool',
+                    },
+                    {
+                        'internalType': 'uint256',
+                        'name': 'principal',
+                        'type': 'uint256',
+                    },
+                    {
+                        'internalType': 'uint256',
+                        'name': 'premium',
+                        'type': 'uint256',
+                    },
+                    {
+                        'internalType': 'uint256',
+                        'name': 'maturity',
+                        'type': 'uint256',
+                    },
+                    {
+                        'internalType': 'uint256',
+                        'name': 'expiry',
+                        'type': 'uint256',
+                    },
+                ],
+                'internalType': 'struct Swivel.Order[]',
+                'name': 'o',
+                'type': 'tuple[]',
+            },
+            {
+                'components': [
+                    {
+                        'internalType': 'uint8',
+                        'name': 'v',
+                        'type': 'uint8',
+                    },
+                    {
+                        'internalType': 'bytes32',
+                        'name': 'r',
+                        'type': 'bytes32',
+                    },
+                    {
+                        'internalType': 'bytes32',
+                        'name': 's',
+                        'type': 'bytes32',
+                    },
+                ],
+                'internalType': 'struct Swivel.Components[]',
+                'name': 's',
+                'type': 'tuple[]',
+            },
+        ],
+        'name': 'lend',
+        'outputs': [
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'uint8',
+                'name': 'p',
+                'type': 'uint8',
+            },
+            {
+                'internalType': 'address',
+                'name': 'u',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'm',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'a',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'address',
+                'name': 'y',
+                'type': 'address',
+            },
+        ],
+        'name': 'lend',
+        'outputs': [
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+
+        ],
+        'name': 'marketPlace',
+        'outputs': [
+            {
+                'internalType': 'address',
+                'name': '',
+                'type': 'address',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'uint8',
+                'name': 'p',
+                'type': 'uint8',
+            },
+            {
+                'internalType': 'address',
+                'name': 'u',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'm',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'a',
+                'type': 'uint256',
+            },
+        ],
+        'name': 'mint',
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+
+        ],
+        'name': 'pendleAddr',
+        'outputs': [
+            {
+                'internalType': 'address',
+                'name': '',
+                'type': 'address',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'uint256',
+                'name': 'f',
+                'type': 'uint256',
+            },
+        ],
+        'name': 'setFee',
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'address',
+                'name': 'm',
+                'type': 'address',
+            },
+        ],
+        'name': 'setMarketPlaceAddress',
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+
+        ],
+        'name': 'swivelAddr',
+        'outputs': [
+            {
+                'internalType': 'address',
+                'name': '',
+                'type': 'address',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+
+        ],
+        'name': 'tempusAddr',
+        'outputs': [
+            {
+                'internalType': 'address',
+                'name': '',
+                'type': 'address',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'address',
+                'name': 'e',
+                'type': 'address',
+            },
+        ],
+        'name': 'withdraw',
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
 ];

--- a/src/constants/abi/marketplace-abi.ts
+++ b/src/constants/abi/marketplace-abi.ts
@@ -1,5 +1,135 @@
 export const MARKETPLACE_ABI = [
-    'function admin() public view returns(address)',
-    'function redeemer() public view returns(address)',
-    'function markets(address underlying, uint256 maturity) public view returns(uint)',
+    {
+        'inputs': [
+            {
+                'internalType': 'address',
+                'name': 'r',
+                'type': 'address',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'constructor',
+    },
+    {
+        'anonymous': false,
+        'inputs': [
+            {
+                'indexed': true,
+                'internalType': 'address',
+                'name': 'underlying',
+                'type': 'address',
+            },
+            {
+                'indexed': true,
+                'internalType': 'uint256',
+                'name': 'maturity',
+                'type': 'uint256',
+            },
+        ],
+        'name': 'CreateMarket',
+        'type': 'event',
+    },
+    {
+        'inputs': [
+
+        ],
+        'name': 'admin',
+        'outputs': [
+            {
+                'internalType': 'address',
+                'name': '',
+                'type': 'address',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'address',
+                'name': 'u',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': 'm',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'address[8]',
+                'name': 't',
+                'type': 'address[8]',
+            },
+            {
+                'internalType': 'string',
+                'name': 'n',
+                'type': 'string',
+            },
+            {
+                'internalType': 'string',
+                'name': 's',
+                'type': 'string',
+            },
+            {
+                'internalType': 'uint8',
+                'name': 'd',
+                'type': 'uint8',
+            },
+        ],
+        'name': 'createMarket',
+        'outputs': [
+            {
+                'internalType': 'bool',
+                'name': '',
+                'type': 'bool',
+            },
+        ],
+        'stateMutability': 'nonpayable',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+            {
+                'internalType': 'address',
+                'name': '',
+                'type': 'address',
+            },
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+            {
+                'internalType': 'uint256',
+                'name': '',
+                'type': 'uint256',
+            },
+        ],
+        'name': 'markets',
+        'outputs': [
+            {
+                'internalType': 'address',
+                'name': '',
+                'type': 'address',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
+    {
+        'inputs': [
+
+        ],
+        'name': 'redeemer',
+        'outputs': [
+            {
+                'internalType': 'address',
+                'name': '',
+                'type': 'address',
+            },
+        ],
+        'stateMutability': 'view',
+        'type': 'function',
+    },
 ];

--- a/src/contracts/lender.ts
+++ b/src/contracts/lender.ts
@@ -1,10 +1,41 @@
-import { Provider } from '@ethersproject/abstract-provider';
+import { Provider, TransactionResponse } from '@ethersproject/abstract-provider';
 import { Signer } from '@ethersproject/abstract-signer';
-import { BigNumber, CallOverrides, Contract } from 'ethers';
+import { SignatureLike } from '@ethersproject/bytes';
+import { BigNumber, BigNumberish, CallOverrides, Contract, utils } from 'ethers';
 import { LENDER_ABI } from '../constants/abi/index.js';
-import { unwrap } from '../helpers/index.js';
+import { Principals } from '../constants/principals.js';
+import { parseOrder, unwrap } from '../helpers/index.js';
+import { Order } from '../types/index.js';
 
 export class Lender {
+
+    /**
+     * A static map of overload signatures for the lend method.
+     *
+     * @remarks
+     * Ethers.js supports solidity function overloading by creating entries in the `Contract.functions` map
+     * which carry the specific overloaded signature in the function name (that's because JS is not typed).
+     * When we want to invoke a specific overload, we need to address the method by its full signature.
+     *
+     * NOTE: This needs to be manually updated if the the abi for the lend method changes. We can't rely on
+     * the order of method overloads in the generated abi to be stable in order to automatically create this map.
+     * If the abi changes, tests should fail, as the generated method signatures from ethers should no longer
+     * match these signatures here.
+     *
+     * NOTE: When the signatures change, the TS overloads need to be updated too, as well as the actual
+     * `lend` implementation which converts and passes arguments to the specific contract method overload.
+     */
+    static lendSignatures: Record<Principals, string> = {
+        [Principals.Illuminate]: 'lend(uint8,address,uint256,uint256,address)',
+        [Principals.Yield]: 'lend(uint8,address,uint256,uint256,address)',
+        [Principals.Swivel]: 'lend(uint8,address,uint256,uint256[],address,(bytes32,address,address,bool,bool,uint256,uint256,uint256,uint256)[],(uint8,bytes32,bytes32)[])',
+        [Principals.Element]: 'lend(uint8,address,uint256,uint256,uint256,uint256,address,bytes32)',
+        [Principals.Pendle]: 'lend(uint8,address,uint256,uint256,uint256,uint256)',
+        [Principals.Tempus]: 'lend(uint8,address,uint256,uint256,uint256,uint256,address,address)',
+        [Principals.Sense]: 'lend(uint8,address,uint256,uint128,uint256,address,address)',
+        [Principals.Apwine]: 'lend(uint8,address,uint256,uint256,uint256,address,uint256)',
+        [Principals.Notional]: 'lend(uint8,address,uint256,uint256)',
+    };
 
     protected contract: Contract;
 
@@ -51,5 +82,224 @@ export class Lender {
     async fees (underlying: string, overrides: CallOverrides = {}): Promise<string> {
 
         return unwrap<BigNumber>(await this.contract.functions.fees(underlying, overrides)).toString();
+    }
+
+    /**
+     * Lend underlying on Illuminate.
+     *
+     * @param p - a {@link Principals} identifier
+     * @param u - underlying address of the market
+     * @param m - maturity timestamp of the market
+     * @param a - amount of underlying tokens to lend
+     * @param y - yield pool that will execute the swap for the principal token
+     */
+    lend (p: Principals.Illuminate, u: string, m: BigNumberish, a: BigNumberish, y: string): Promise<TransactionResponse>;
+
+    /**
+     * Lend underlying on Yield.
+     *
+     * @param p - a {@link Principals} identifier
+     * @param u - underlying address of the market
+     * @param m - maturity timestamp of the market
+     * @param a - amount of underlying tokens to lend
+     * @param y - yield pool that will execute the swap for the principal token
+     */
+    lend (p: Principals.Yield, u: string, m: BigNumberish, a: BigNumberish, y: string): Promise<TransactionResponse>;
+
+    /**
+     * Lend underlying on Swivel.
+     *
+     * @param p - a {@link Principals} identifier
+     * @param u - underlying address of the market
+     * @param m - maturity timestamp of the market
+     * @param a - array of amounts of underlying tokens lent to each order in the orders array
+     * @param y - yield pool
+     * @param o - array of Swivel orders to fill
+     * @param s - array of signatures for each order in the orders array
+     */
+    lend (p: Principals.Swivel, u: string, m: BigNumberish, a: BigNumberish[], y: string, o: Order[], s: SignatureLike[]): Promise<TransactionResponse>;
+
+    /**
+     * Lend underlying on Element.
+     *
+     * @param p - a {@link Principals} identifier
+     * @param u - underlying address of the market
+     * @param m - maturity timestamp of the market
+     * @param a - amount of principal tokens to lend
+     * @param r - minimum amount to return (this puts a cap on allowed slippage)
+     * @param d - deadline timestamp by which the swap must be executed
+     * @param e - element pool to lend to
+     * @param i - id of the pool
+     */
+    lend (p: Principals.Element, u: string, m: BigNumberish, a: BigNumberish, r: BigNumberish, d: BigNumberish, e: string, i: string): Promise<TransactionResponse>;
+
+    /**
+     * Lend underlying on Pendle.
+     *
+     * @param p - a {@link Principals} identifier
+     * @param u - underlying address of the market
+     * @param m - maturity timestamp of the market
+     * @param a - amount of principal tokens to lend
+     * @param r - minimum amount to return (this puts a cap on allowed slippage)
+     * @param d - deadline timestamp by which the swap must be executed
+     */
+    lend (p: Principals.Pendle, u: string, m: BigNumberish, a: BigNumberish, r: BigNumberish, d: BigNumberish): Promise<TransactionResponse>;
+
+    /**
+     * Lend underlying on Tempus.
+     *
+     * @param p - a {@link Principals} identifier
+     * @param u - underlying address of the market
+     * @param m - maturity timestamp of the market
+     * @param a - amount of principal tokens to lend
+     * @param r - minimum amount to return (this puts a cap on allowed slippage)
+     * @param d - deadline timestamp by which the swap must be executed
+     * @param t - tempus pool that houses the underlying principal tokens
+     * @param x - tempus amm that executes the swap
+     */
+    lend (p: Principals.Tempus, u: string, m: BigNumberish, a: BigNumberish, r: BigNumberish, d: BigNumberish, t: string, x: string): Promise<TransactionResponse>;
+
+    /**
+     * Lend underlying on Sense.
+     *
+     * @param p - a {@link Principals} identifier
+     * @param u - underlying address of the market
+     * @param m - maturity timestamp of the market
+     * @param a - amount of underlying tokens to lend (this is a 128 bit int)
+     * @param r - minimum amount to return (this puts a cap on allowed slippage)
+     * @param x - sense amm that executes the swap
+     * @param s - contract that holds the principal token for this market
+     */
+    lend (p: Principals.Sense, u: string, m: BigNumberish, a: BigNumberish, r: BigNumberish, x: string, s: string): Promise<TransactionResponse>;
+
+    /**
+     * Lend underlying on APWine.
+     *
+     * @param p - a {@link Principals} identifier
+     * @param u - underlying address of the market
+     * @param m - maturity timestamp of the market
+     * @param a - amount of principal tokens to lend
+     * @param r - minimum amount to return (this puts a cap on allowed slippage)
+     * @param pool - address of a given APWine pool
+     * @param i - id of the pool
+     */
+    lend (p: Principals.Apwine, u: string, m: BigNumberish, a: BigNumberish, r: BigNumberish, pool: string, i: BigNumberish): Promise<TransactionResponse>;
+
+    /**
+     * Lend underlying on Notional.
+     *
+     * @param p - a {@link Principals} identifier
+     * @param u - underlying address of the market
+     * @param m - maturity timestamp of the market
+     * @param a - amount of principal tokens to lend
+     */
+    lend (p: Principals.Notional, u: string, m: BigNumberish, a: BigNumberish): Promise<TransactionResponse>;
+
+    async lend (p: Principals, u: string, m: BigNumberish, a1?: unknown, a2?: unknown, a3?: unknown, a4?: unknown, a5?: unknown): Promise<TransactionResponse> {
+
+        switch (p) {
+
+            case Principals.Illuminate:
+
+                return await this.contract.functions[Lender.lendSignatures[Principals.Illuminate]](
+                    p,
+                    u,
+                    BigNumber.from(m),
+                    BigNumber.from(a1),
+                    a2,
+                ) as TransactionResponse;
+
+            case Principals.Yield:
+
+                return await this.contract.functions[Lender.lendSignatures[Principals.Yield]](
+                    p,
+                    u,
+                    BigNumber.from(m),
+                    BigNumber.from(a1),
+                    a2,
+                ) as TransactionResponse;
+
+            case Principals.Swivel:
+
+                return await this.contract.functions[Lender.lendSignatures[Principals.Swivel]](
+                    p,
+                    u,
+                    BigNumber.from(m),
+                    (a1 as BigNumberish[]).map(amount => BigNumber.from(amount)),
+                    a2,
+                    (a3 as Order[]).map(order => parseOrder(order)),
+                    (a4 as SignatureLike[]).map(signature => utils.splitSignature(signature)),
+                ) as TransactionResponse;
+
+            case Principals.Element:
+
+                return await this.contract.functions[Lender.lendSignatures[Principals.Element]](
+                    p,
+                    u,
+                    BigNumber.from(m),
+                    BigNumber.from(a1),
+                    BigNumber.from(a2),
+                    BigNumber.from(a3),
+                    a4,
+                    a5,
+                ) as TransactionResponse;
+
+            case Principals.Pendle:
+
+                return await this.contract.functions[Lender.lendSignatures[Principals.Pendle]](
+                    p,
+                    u,
+                    BigNumber.from(m),
+                    BigNumber.from(a1),
+                    BigNumber.from(a2),
+                    BigNumber.from(a3),
+                ) as TransactionResponse;
+
+            case Principals.Tempus:
+
+                return await this.contract.functions[Lender.lendSignatures[Principals.Tempus]](
+                    p,
+                    u,
+                    BigNumber.from(m),
+                    BigNumber.from(a1),
+                    BigNumber.from(a2),
+                    BigNumber.from(a3),
+                    a4,
+                    a5,
+                ) as TransactionResponse;
+
+            case Principals.Sense:
+
+                return await this.contract.functions[Lender.lendSignatures[Principals.Sense]](
+                    p,
+                    u,
+                    BigNumber.from(m),
+                    BigNumber.from(a1),
+                    BigNumber.from(a2),
+                    a3,
+                    a4,
+                ) as TransactionResponse;
+
+            case Principals.Apwine:
+
+                return await this.contract.functions[Lender.lendSignatures[Principals.Apwine]](
+                    p,
+                    u,
+                    BigNumber.from(m),
+                    BigNumber.from(a1),
+                    BigNumber.from(a2),
+                    a3,
+                    BigNumber.from(a4),
+                ) as TransactionResponse;
+
+            case Principals.Notional:
+
+                return await this.contract.functions[Lender.lendSignatures[Principals.Notional]](
+                    p,
+                    u,
+                    BigNumber.from(m),
+                    BigNumber.from(a1),
+                ) as TransactionResponse;
+        }
     }
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,1 +1,2 @@
+export * from './order.js';
 export * from './result.js';

--- a/src/helpers/order.ts
+++ b/src/helpers/order.ts
@@ -1,0 +1,34 @@
+import { BigNumber, utils } from 'ethers';
+import { Order } from '../types/index.js';
+
+interface EthersOrder {
+    key: Uint8Array;
+    maker: string;
+    underlying: string;
+    vault: boolean;
+    exit: boolean;
+    principal: BigNumber;
+    premium: BigNumber;
+    maturity: BigNumber;
+    expiry: BigNumber;
+}
+
+/**
+ * Converts an {@link Order} into an `ethers.js` specific order.
+ *
+ * @param o - the order to convert
+ */
+export function parseOrder (o: Order): EthersOrder {
+
+    return {
+        key: utils.arrayify(o.key),
+        maker: o.maker,
+        underlying: o.underlying,
+        vault: o.vault,
+        exit: o.exit,
+        principal: BigNumber.from(o.principal),
+        premium: BigNumber.from(o.premium),
+        maturity: BigNumber.from(o.maturity),
+        expiry: BigNumber.from(o.expiry),
+    };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './order.js';

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,0 +1,14 @@
+/**
+ * A Swivel order.
+ */
+export interface Order {
+    key: string;
+    maker: string;
+    underlying: string;
+    vault: boolean;
+    exit: boolean;
+    principal: string;
+    premium: string;
+    maturity: string;
+    expiry: string;
+}

--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -1,6 +1,6 @@
 // TODO: these addresses are the rinkeby addresses for temporary on-chain testing and will be removed soon...
 export const ADDRESSES = {
-    LENDER: '0x915c23620aD5c60Fa9F9280A64AD9bD290317D39',
-    REDEEMER: '0x936E467Dbb4f73B44E0dcF78aA2138275fca04ba',
-    MARKETPLACE: '0x1bD3197487E3eac7Ed0fEeb6cB5bc04370639C05',
+    LENDER: '0x888cF9ca505189619CAe52721E2C6D31EDCD11F2',
+    REDEEMER: '0xa5Ba7D94C6bdCfD50518c00e204304deC17fe54f',
+    MARKETPLACE: '0x86b93ac76815E37373Ae5665A83f9db8311d8300',
 };

--- a/test/helpers/mock.ts
+++ b/test/helpers/mock.ts
@@ -1,4 +1,5 @@
-import { Contract, ContractFunction } from 'ethers';
+import { TransactionReceipt, TransactionResponse } from '@ethersproject/abstract-provider';
+import { BigNumber, Contract, ContractFunction } from 'ethers';
 import { SinonStub, stub } from 'sinon';
 import { Result } from '../../src/helpers/result.js';
 import { Lender, MarketPlace } from '../../src/index.js';
@@ -19,7 +20,7 @@ export type HasContract = {
 /**
  * A helper type to define the return type of an ethers contract method.
  */
-export type TypedContractResult<T = unknown> = T extends unknown[] ? Result<T> : Result<[T]>;
+export type TypedContractResult<T = unknown> = T extends TransactionResponse ? T : T extends unknown[] ? Result<T> : Result<[T]>;
 
 /**
  * A helper type to add a return type an ethers `Contract`'s `functions` object.
@@ -35,7 +36,7 @@ export type TypedContractFunctions<T = unknown> = {
  * @param m - the contract method to mock
  * @returns the mocked method as {@link SinonStub}
  */
-export const mock = <T = unknown>(c: IlluminateContract, m: string): SinonStub<unknown[], Promise<TypedContractResult<T>>> => {
+export const mockMethod = <T = unknown>(c: IlluminateContract, m: string): SinonStub<unknown[], Promise<TypedContractResult<T>>> => {
 
     // clone the protected ethers contract to make it configurable
     const contract = clone((c as unknown as HasContract).contract);
@@ -50,7 +51,24 @@ export const mock = <T = unknown>(c: IlluminateContract, m: string): SinonStub<u
     return mock;
 };
 
-
+/**
+ * Mock a transaction response object.
+ *
+ * @param response - an optional partial transaction response
+ */
+export const mockResponse = (response?: Partial<TransactionResponse>): TransactionResponse => ({
+    chainId: 1,
+    confirmations: 1,
+    data: '',
+    from: '',
+    gasLimit: BigNumber.from('1000'),
+    hash: '0xresponse',
+    nonce: 1,
+    value: BigNumber.from('0'),
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    wait: (c?: number) => Promise.resolve({} as TransactionReceipt),
+    ...response,
+});
 
 /**
  * Clone an object to make a frozen or non-configurable object configurable again.

--- a/test/lender.spec.ts
+++ b/test/lender.spec.ts
@@ -1,10 +1,13 @@
 import assert from 'assert';
-import { Provider } from '@ethersproject/abstract-provider';
+import { Provider, TransactionResponse } from '@ethersproject/abstract-provider';
 import { Signer } from '@ethersproject/abstract-signer';
-import { BigNumber, getDefaultProvider, providers, Wallet } from 'ethers';
+import { SignatureLike } from '@ethersproject/bytes';
+import { BigNumber, getDefaultProvider, providers, utils, Wallet } from 'ethers';
 import { suite, suiteSetup, test } from 'mocha';
-import { Lender } from '../src/index.js';
-import { ADDRESSES, mock } from './helpers/index.js';
+import { parseOrder } from '../src/helpers/index.js';
+import { Lender, Principals } from '../src/index.js';
+import { Order } from '../src/types/index.js';
+import { ADDRESSES, mockMethod, mockResponse } from './helpers/index.js';
 
 suite('lender', () => {
 
@@ -61,7 +64,7 @@ suite('lender', () => {
 
         // mock the Lender contract's `admin` method and tell it to resolve with a typed `Result`
         // mock will throw if 'admin' doesn't exist on the contract, so tests will fail if it's removed from the abi
-        mock<string>(lender, 'admin').resolves([expected]);
+        mockMethod<string>(lender, 'admin').resolves([expected]);
 
         const result = await lender.admin();
 
@@ -74,7 +77,7 @@ suite('lender', () => {
 
         const expected = '0xmarketPlace';
 
-        mock<string>(lender, 'marketPlace').resolves([expected]);
+        mockMethod<string>(lender, 'marketPlace').resolves([expected]);
 
         const result = await lender.marketPlace();
 
@@ -87,7 +90,7 @@ suite('lender', () => {
 
         const expected = '0xswivelAddr';
 
-        mock<string>(lender, 'swivelAddr').resolves([expected]);
+        mockMethod<string>(lender, 'swivelAddr').resolves([expected]);
 
         const result = await lender.swivelAddr();
 
@@ -100,7 +103,7 @@ suite('lender', () => {
 
         const expected = '0xpendleAddr';
 
-        mock<string>(lender, 'pendleAddr').resolves([expected]);
+        mockMethod<string>(lender, 'pendleAddr').resolves([expected]);
 
         const result = await lender.pendleAddr();
 
@@ -113,7 +116,7 @@ suite('lender', () => {
 
         const expected = '0xtempusAddr';
 
-        mock<string>(lender, 'tempusAddr').resolves([expected]);
+        mockMethod<string>(lender, 'tempusAddr').resolves([expected]);
 
         const result = await lender.tempusAddr();
 
@@ -128,7 +131,7 @@ suite('lender', () => {
 
         // feenominator returns a uint256, so ethers will return a BigNumber
         // we create a mock Result with a BigNumber and assert the HOC converts it to string
-        mock<BigNumber>(lender, 'feenominator').resolves([BigNumber.from(expected)]);
+        mockMethod<BigNumber>(lender, 'feenominator').resolves([BigNumber.from(expected)]);
 
         const result = await lender.feenominator();
 
@@ -144,10 +147,348 @@ suite('lender', () => {
 
         // fees returns a uint256, so ethers will return a BigNumber
         // we create a mock Result with a BigNumber and assert the HOC converts it to string
-        mock<BigNumber>(lender, 'fees').resolves([BigNumber.from(expected)]);
+        mockMethod<BigNumber>(lender, 'fees').resolves([BigNumber.from(expected)]);
 
         const result = await lender.fees(underlying);
 
         assert.strictEqual(result, expected);
+    });
+
+    suite('lend', () => {
+
+        let principal: Principals;
+
+        const underlying = '0xunderlying';
+        const maturity = '1654638431';
+        const amount = utils.parseEther('100').toString();
+        const minReturn = utils.parseEther('95').toString();
+        const deadline = '1654642073';
+        const pool = '0xpool';
+
+        test('illuminate', async () => {
+
+            const lender = new Lender(ADDRESSES.LENDER, signer);
+
+            principal = Principals.Illuminate;
+
+            const lend = mockMethod<TransactionResponse>(lender, Lender.lendSignatures[principal]);
+            const response = mockResponse();
+            lend.resolves(response);
+
+            const result = await lender.lend(principal, underlying, maturity, amount, pool);
+
+            assert.strictEqual(result.hash, '0xresponse');
+
+            // get the call arguments
+            const args = lend.getCall(0).args;
+
+            // assert the correct amount of call arguments
+            assert.strictEqual(args.length, 5);
+
+            const [passedPrincipal, passedUnderlying, passedMaturity, passedAmount, passedPool] = args;
+
+            // assert the arguments are being converted correctly
+            assert.strictEqual(passedPrincipal, principal);
+            assert.strictEqual(passedUnderlying, underlying);
+            assert.deepStrictEqual(passedMaturity, BigNumber.from(maturity));
+            assert.deepStrictEqual(passedAmount, BigNumber.from(amount));
+            assert.strictEqual(passedPool, pool);
+        });
+
+        test('yield', async () => {
+
+            const lender = new Lender(ADDRESSES.LENDER, signer);
+
+            principal = Principals.Yield;
+
+            const lend = mockMethod<TransactionResponse>(lender, Lender.lendSignatures[principal]);
+            const response = mockResponse();
+            lend.resolves(response);
+
+            const result = await lender.lend(principal, underlying, maturity, amount, pool);
+
+            assert.strictEqual(result.hash, '0xresponse');
+
+            // get the call arguments
+            const args = lend.getCall(0).args;
+
+            // assert the correct amount of call arguments
+            assert.strictEqual(args.length, 5);
+
+            const [passedPrincipal, passedUnderlying, passedMaturity, passedAmount, passedPool] = args;
+
+            // assert the arguments are being converted correctly
+            assert.strictEqual(passedPrincipal, principal);
+            assert.strictEqual(passedUnderlying, underlying);
+            assert.deepStrictEqual(passedMaturity, BigNumber.from(maturity));
+            assert.deepStrictEqual(passedAmount, BigNumber.from(amount));
+            assert.strictEqual(passedPool, pool);
+        });
+
+        test('swivel', async () => {
+
+            const lender = new Lender(ADDRESSES.LENDER, signer);
+
+            principal = Principals.Swivel;
+
+            const amounts = [
+                utils.parseEther('10').toString(),
+                utils.parseEther('200').toString(),
+            ];
+
+            const orders: Order[] = [
+                {
+                    key: '0xfb1700b125bdb80a6c11c181325a5a744fe00a098f379aa31fcbcdfb1d6d1c01',
+                    maker: '0xmaker1',
+                    underlying: '0xunderlying',
+                    vault: false,
+                    exit: false,
+                    principal: '10000000000000000000',
+                    premium: '1000000000000000000',
+                    maturity: '12345678',
+                    expiry: '22345678',
+                },
+                {
+                    key: '0xfb1700b125bdb80a6c11c181325a5a744fe00a098f379aa31fcbcdfb1d6d1c01',
+                    maker: '0xmaker2',
+                    underlying: '0xunderlying',
+                    vault: false,
+                    exit: false,
+                    principal: '200000000000000000000',
+                    premium: '20000000000000000000',
+                    maturity: '12345678',
+                    expiry: '22345678',
+                },
+            ];
+
+            const signatures: SignatureLike[] = [
+                '0xa5af5edd029fb82bef79cae459d8007ff20c078e25114217c921dc60e31ce0a06014954014d6ee16840a1ead70ec6797b64e42532a86edc744a451b07a1bb41d1b',
+                '0xe3dea176cfd7dacd1fe7424f633789b8fc7da0fa23d7e1bd64404bd29d9115d4656c0bf83af468dc5036309403d8f1a0809be0a9db18e314c40fd7f252e6fb971b',
+            ];
+
+            const lend = mockMethod<TransactionResponse>(lender, Lender.lendSignatures[principal]);
+            const response = mockResponse();
+            lend.resolves(response);
+
+            const result = await lender.lend(principal, underlying, maturity, amounts, pool, orders, signatures);
+
+            assert.strictEqual(result.hash, '0xresponse');
+
+            // get the call arguments
+            const args = lend.getCall(0).args;
+
+            // assert the correct amount of call arguments
+            assert.strictEqual(args.length, 7);
+
+            const [passedPrincipal, passedUnderlying, passedMaturity, passedAmounts, passedPool, passedOrders, passedSignatures] = args;
+
+            // assert the arguments are being converted correctly
+            assert.strictEqual(passedPrincipal, principal);
+            assert.strictEqual(passedUnderlying, underlying);
+            assert.deepStrictEqual(passedMaturity, BigNumber.from(maturity));
+            assert.deepStrictEqual(passedAmounts, amounts.map(amount => BigNumber.from(amount)));
+            assert.strictEqual(passedPool, pool);
+            assert.deepStrictEqual(passedOrders, orders.map(order => parseOrder(order)));
+            assert.deepStrictEqual(passedSignatures, signatures.map(signature => utils.splitSignature(signature)));
+        });
+
+        test('element', async () => {
+
+            const lender = new Lender(ADDRESSES.LENDER, signer);
+
+            principal = Principals.Element;
+
+            const poolId = '0xpoolId';
+
+            const lend = mockMethod<TransactionResponse>(lender, Lender.lendSignatures[principal]);
+            const response = mockResponse();
+            lend.resolves(response);
+
+            const result = await lender.lend(principal, underlying, maturity, amount, minReturn, deadline, pool, poolId);
+
+            assert.strictEqual(result.hash, '0xresponse');
+
+            // get the call arguments
+            const args = lend.getCall(0).args;
+
+            // assert the correct amount of call arguments
+            assert.strictEqual(args.length, 8);
+
+            const [passedPrincipal, passedUnderlying, passedMaturity, passedAmount, passedMinReturn, passedDeadline, passedPool, passedPoolId] = args;
+
+            // assert the arguments are being converted correctly
+            assert.strictEqual(passedPrincipal, principal);
+            assert.strictEqual(passedUnderlying, underlying);
+            assert.deepStrictEqual(passedMaturity, BigNumber.from(maturity));
+            assert.deepStrictEqual(passedAmount, BigNumber.from(amount));
+            assert.deepStrictEqual(passedMinReturn, BigNumber.from(minReturn));
+            assert.deepStrictEqual(passedDeadline, BigNumber.from(deadline));
+            assert.strictEqual(passedPool, pool);
+            assert.strictEqual(passedPoolId, poolId);
+        });
+
+        test('pendle', async () => {
+
+            const lender = new Lender(ADDRESSES.LENDER, signer);
+
+            principal = Principals.Pendle;
+
+            const lend = mockMethod<TransactionResponse>(lender, Lender.lendSignatures[principal]);
+            const response = mockResponse();
+            lend.resolves(response);
+
+            const result = await lender.lend(principal, underlying, maturity, amount, minReturn, deadline);
+
+            assert.strictEqual(result.hash, '0xresponse');
+
+            // get the call arguments
+            const args = lend.getCall(0).args;
+
+            // assert the correct amount of call arguments
+            assert.strictEqual(args.length, 6);
+
+            const [passedPrincipal, passedUnderlying, passedMaturity, passedAmount, passedMinReturn, passedDeadline] = args;
+
+            // assert the arguments are being converted correctly
+            assert.strictEqual(passedPrincipal, principal);
+            assert.strictEqual(passedUnderlying, underlying);
+            assert.deepStrictEqual(passedMaturity, BigNumber.from(maturity));
+            assert.deepStrictEqual(passedAmount, BigNumber.from(amount));
+            assert.deepStrictEqual(passedMinReturn, BigNumber.from(minReturn));
+            assert.deepStrictEqual(passedDeadline, BigNumber.from(deadline));
+        });
+
+        test('tempus', async () => {
+
+            const lender = new Lender(ADDRESSES.LENDER, signer);
+
+            principal = Principals.Tempus;
+
+            const amm = '0xamm';
+
+            const lend = mockMethod<TransactionResponse>(lender, Lender.lendSignatures[principal]);
+            const response = mockResponse();
+            lend.resolves(response);
+
+            const result = await lender.lend(principal, underlying, maturity, amount, minReturn, deadline, pool, amm);
+
+            assert.strictEqual(result.hash, '0xresponse');
+
+            // get the call arguments
+            const args = lend.getCall(0).args;
+
+            // assert the correct amount of call arguments
+            assert.strictEqual(args.length, 8);
+
+            const [passedPrincipal, passedUnderlying, passedMaturity, passedAmount, passedMinReturn, passedDeadline, passedPool, passedAmm] = args;
+
+            // assert the arguments are being converted correctly
+            assert.strictEqual(passedPrincipal, principal);
+            assert.strictEqual(passedUnderlying, underlying);
+            assert.deepStrictEqual(passedMaturity, BigNumber.from(maturity));
+            assert.deepStrictEqual(passedAmount, BigNumber.from(amount));
+            assert.deepStrictEqual(passedMinReturn, BigNumber.from(minReturn));
+            assert.deepStrictEqual(passedDeadline, BigNumber.from(deadline));
+            assert.strictEqual(passedPool, pool);
+            assert.strictEqual(passedAmm, amm);
+        });
+
+        test('sense', async () => {
+
+            const lender = new Lender(ADDRESSES.LENDER, signer);
+
+            principal = Principals.Sense;
+
+            const amm = '0xamm';
+            const token = '0xtoken';
+
+            const lend = mockMethod<TransactionResponse>(lender, Lender.lendSignatures[principal]);
+            const response = mockResponse();
+            lend.resolves(response);
+
+            const result = await lender.lend(principal, underlying, maturity, amount, minReturn, amm, token);
+
+            assert.strictEqual(result.hash, '0xresponse');
+
+            // get the call arguments
+            const args = lend.getCall(0).args;
+
+            // assert the correct amount of call arguments
+            assert.strictEqual(args.length, 7);
+
+            const [passedPrincipal, passedUnderlying, passedMaturity, passedAmount, passedMinReturn, passedAmm, passedToken] = args;
+
+            // assert the arguments are being converted correctly
+            assert.strictEqual(passedPrincipal, principal);
+            assert.strictEqual(passedUnderlying, underlying);
+            assert.deepStrictEqual(passedMaturity, BigNumber.from(maturity));
+            assert.deepStrictEqual(passedAmount, BigNumber.from(amount));
+            assert.deepStrictEqual(passedMinReturn, BigNumber.from(minReturn));
+            assert.strictEqual(passedAmm, amm);
+            assert.strictEqual(passedToken, token);
+        });
+
+        test('apwine', async () => {
+
+            const lender = new Lender(ADDRESSES.LENDER, signer);
+
+            principal = Principals.Apwine;
+
+            const poolId = '12345678';
+
+            const lend = mockMethod<TransactionResponse>(lender, Lender.lendSignatures[principal]);
+            const response = mockResponse();
+            lend.resolves(response);
+
+            const result = await lender.lend(principal, underlying, maturity, amount, minReturn, pool, poolId);
+
+            assert.strictEqual(result.hash, '0xresponse');
+
+            // get the call arguments
+            const args = lend.getCall(0).args;
+
+            // assert the correct amount of call arguments
+            assert.strictEqual(args.length, 7);
+
+            const [passedPrincipal, passedUnderlying, passedMaturity, passedAmount, passedMinReturn, passedPool, passedPoolId] = args;
+
+            // assert the arguments are being converted correctly
+            assert.strictEqual(passedPrincipal, principal);
+            assert.strictEqual(passedUnderlying, underlying);
+            assert.deepStrictEqual(passedMaturity, BigNumber.from(maturity));
+            assert.deepStrictEqual(passedAmount, BigNumber.from(amount));
+            assert.deepStrictEqual(passedMinReturn, BigNumber.from(minReturn));
+            assert.strictEqual(passedPool, pool);
+            assert.deepStrictEqual(passedPoolId, BigNumber.from(poolId));
+        });
+
+        test('notional', async () => {
+
+            const lender = new Lender(ADDRESSES.LENDER, signer);
+
+            principal = Principals.Notional;
+
+            const lend = mockMethod<TransactionResponse>(lender, Lender.lendSignatures[principal]);
+            const response = mockResponse();
+            lend.resolves(response);
+
+            const result = await lender.lend(principal, underlying, maturity, amount);
+
+            assert.strictEqual(result.hash, '0xresponse');
+
+            // get the call arguments
+            const args = lend.getCall(0).args;
+
+            // assert the correct amount of call arguments
+            assert.strictEqual(args.length, 4);
+
+            const [passedPrincipal, passedUnderlying, passedMaturity, passedAmount] = args;
+
+            // assert the arguments are being converted correctly
+            assert.strictEqual(passedPrincipal, principal);
+            assert.strictEqual(passedUnderlying, underlying);
+            assert.deepStrictEqual(passedMaturity, BigNumber.from(maturity));
+            assert.deepStrictEqual(passedAmount, BigNumber.from(amount));
+        });
     });
 });

--- a/test/marketplace.spec.ts
+++ b/test/marketplace.spec.ts
@@ -1,20 +1,17 @@
 import assert from 'assert';
 import { Provider } from '@ethersproject/abstract-provider';
-import { Signer } from '@ethersproject/abstract-signer';
-import { getDefaultProvider, providers, Wallet } from 'ethers';
+import { getDefaultProvider, providers } from 'ethers';
 import { suite, suiteSetup, test } from 'mocha';
 import { MarketPlace } from '../src/index.js';
-import { ADDRESSES, mock } from './helpers/index.js';
+import { ADDRESSES, mockMethod } from './helpers/index.js';
 
 suite('marketplace', () => {
 
     let provider: Provider;
-    let signer: Signer;
 
     suiteSetup(() => {
 
         provider = getDefaultProvider();
-        signer = Wallet.createRandom().connect(provider);
     });
 
     // TODO: on-chain test calls are only temporary for debugging, will be removed soon...
@@ -60,7 +57,7 @@ suite('marketplace', () => {
 
         // mock the MarketPlace contract's `admin` method and tell it to resolve with a typed `Result`
         // mock will throw if 'admin' doesn't exist on the contract, so tests will fail if it's removed from the abi
-        mock<string>(marketplace, 'admin').resolves([expected]);
+        mockMethod<string>(marketplace, 'admin').resolves([expected]);
 
         const result = await marketplace.admin();
 
@@ -73,7 +70,7 @@ suite('marketplace', () => {
 
         const expected = '0xredeemer';
 
-        mock<string>(marketplace, 'redeemer').resolves([expected]);
+        mockMethod<string>(marketplace, 'redeemer').resolves([expected]);
 
         const result = await marketplace.redeemer();
 

--- a/test/order.spec.ts
+++ b/test/order.spec.ts
@@ -1,0 +1,45 @@
+import assert from 'assert';
+import { BigNumber } from 'ethers';
+import { suite } from 'mocha';
+import { parseOrder } from '../src/helpers/index.js';
+import { Order } from '../src/types/index.js';
+
+suite('parseOrder', () => {
+
+    test('parse an order', () => {
+
+        const order: Order = {
+            key: '0xf15a6cb51c934f862f17844898a7f39cf1015349a670e6eaf4a90ff6b246d752',
+            maker: '0x1fd4F104738cB95a9e100a5d2a8AEF6989850D4a',
+            underlying: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+            exit: true,
+            vault: false,
+            principal: '27141789513',
+            premium: '54283579',
+            maturity: '1656039600',
+            expiry: '1654737361',
+        };
+
+        const parsed = parseOrder(order);
+
+        assert(parsed.key instanceof Uint8Array);
+        assert(parsed.key.length === 32);
+
+        assert.strictEqual(parsed.maker, order.maker);
+        assert.strictEqual(parsed.underlying, order.underlying);
+        assert.strictEqual(parsed.exit, order.exit);
+        assert.strictEqual(parsed.vault, order.vault);
+
+        assert(parsed.principal instanceof BigNumber);
+        assert.strictEqual(parsed.principal.toString(), order.principal);
+
+        assert(parsed.premium instanceof BigNumber);
+        assert.strictEqual(parsed.premium.toString(), order.premium);
+
+        assert(parsed.maturity instanceof BigNumber);
+        assert.strictEqual(parsed.maturity.toString(), order.maturity);
+
+        assert(parsed.expiry instanceof BigNumber);
+        assert.strictEqual(parsed.expiry.toString(), order.expiry);
+    });
+});


### PR DESCRIPTION
add `lend` implementation to lender hoc;
add Swivel order type;
add helper for parsing Swivel orders;
update abi's to latest autogenerated abi's;
update contract addresses to latest rinkeby deploy;
add `mockResponse` test helper;
update `TypedContractResult` to allow tx responses;
add tests for all `lend` overloads;
add tests for order parser;

references #1