### PR TITLE
refactor(test): refactor getter tests

### DIFF
--- a/src/contracts/redeemer.ts
+++ b/src/contracts/redeemer.ts
@@ -2,7 +2,7 @@ import { Provider, TransactionResponse } from '@ethersproject/abstract-provider'
 import { Signer } from '@ethersproject/abstract-signer';
 import { BigNumber, BigNumberish, CallOverrides, Contract, PayableOverrides } from 'ethers';
 import { REDEEMER_ABI } from '../constants/abi/index.js';
-import { Principals } from '../constants/principals.js';
+import { Principals } from '../constants/index.js';
 import { unwrap } from '../helpers/index.js';
 
 export class Redeemer {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,1 @@
-export * from './markets.js';
 export * from './order.js';

--- a/src/types/markets.ts
+++ b/src/types/markets.ts
@@ -1,8 +1,0 @@
-/**
- * A fixed-length array of principal token addresses.
- *
- * @remarks
- * Each principal token address corresponds to a {@link Principals} enum value on the
- * same position (the ordering is defined by the order of the {@link Principals} enum).
- */
-export type Markets = [string, string, string, string, string, string, string, string, string];

--- a/test/lender.spec.ts
+++ b/test/lender.spec.ts
@@ -7,9 +7,15 @@ import { suite, suiteSetup, test } from 'mocha';
 import { parseOrder } from '../src/helpers/index.js';
 import { Lender, Principals } from '../src/index.js';
 import { Order } from '../src/types/index.js';
-import { ADDRESSES, mockMethod, mockResponse } from './helpers/index.js';
+import { ADDRESSES, assertGetter, mockMethod, mockResponse } from './helpers/index.js';
 
 suite('lender', () => {
+
+    const callOverrides: CallOverrides = {
+        gasLimit: '1000',
+        from: '0xfrom',
+        nonce: 1,
+    };
 
     let provider: Provider;
     let signer: Signer;
@@ -58,270 +64,72 @@ suite('lender', () => {
 
     suite('admin', () => {
 
-        const expected = '0xadmin';
+        test('unwraps result and accepts transaction overrides', async () => {
 
-        const overrides: CallOverrides = {
-            gasLimit: '1000',
-            from: '0xfrom',
-            nonce: 1,
-        };
-
-        test('unwraps result', async () => {
-
-            const lender = new Lender(ADDRESSES.LENDER, provider);
-
-            // mock the Lender contract's `admin` method and tell it to resolve with a typed `Result`
-            // mock will throw if 'admin' doesn't exist on the contract, so tests will fail if it's removed from the abi
-            const admin = mockMethod<string>(lender, 'admin');
-            admin.resolves([expected]);
-
-            const result = await lender.admin();
-
-            assert.strictEqual(result, expected);
-
-            const args = admin.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, {});
-        });
-
-        test('accepts transaction overrides', async () => {
-
-            const lender = new Lender(ADDRESSES.LENDER, provider);
-
-            const admin = mockMethod<string>(lender, 'admin');
-            admin.resolves([expected]);
-
-            const result = await lender.admin(overrides);
-
-            assert.strictEqual(result, expected);
-
-            const args = admin.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, overrides);
+            await assertGetter(
+                new Lender(ADDRESSES.LENDER, provider),
+                'admin',
+                '0xadmin',
+                callOverrides,
+            );
         });
     });
 
     suite('marketPlace', () => {
 
-        const expected = '0xmarketPlace';
+        test('unwraps result and accepts transaction overrides', async () => {
 
-        const overrides: CallOverrides = {
-            gasLimit: '1000',
-            from: '0xfrom',
-            nonce: 1,
-        };
-
-        test('unwraps result', async () => {
-
-            const lender = new Lender(ADDRESSES.LENDER, provider);
-
-            const marketPlace = mockMethod<string>(lender, 'marketPlace');
-            marketPlace.resolves([expected]);
-
-            const result = await lender.marketPlace();
-
-            assert.strictEqual(result, expected);
-
-            const args = marketPlace.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, {});
-        });
-
-        test('accepts transaction overrides', async () => {
-
-            const lender = new Lender(ADDRESSES.LENDER, provider);
-
-            const marketPlace = mockMethod<string>(lender, 'marketPlace');
-            marketPlace.resolves([expected]);
-
-            const result = await lender.marketPlace(overrides);
-
-            assert.strictEqual(result, expected);
-
-            const args = marketPlace.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, overrides);
+            await assertGetter(
+                new Lender(ADDRESSES.LENDER, provider),
+                'marketPlace',
+                '0xmarketPlace',
+                callOverrides,
+            );
         });
     });
 
     suite('swivelAddr', () => {
 
-        const expected = '0xswivelAddr';
+        test('unwraps result and accepts transaction overrides', async () => {
 
-        const overrides: CallOverrides = {
-            gasLimit: '1000',
-            from: '0xfrom',
-            nonce: 1,
-        };
-
-        test('unwraps result', async () => {
-
-            const lender = new Lender(ADDRESSES.LENDER, provider);
-
-            const swivelAddr = mockMethod<string>(lender, 'swivelAddr');
-            swivelAddr.resolves([expected]);
-
-            const result = await lender.swivelAddr();
-
-            assert.strictEqual(result, expected);
-
-            const args = swivelAddr.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, {});
-        });
-
-        test('accepts transaction overrides', async () => {
-
-            const lender = new Lender(ADDRESSES.LENDER, provider);
-
-            const swivelAddr = mockMethod<string>(lender, 'swivelAddr');
-            swivelAddr.resolves([expected]);
-
-            const result = await lender.swivelAddr(overrides);
-
-            assert.strictEqual(result, expected);
-
-            const args = swivelAddr.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, overrides);
+            await assertGetter(
+                new Lender(ADDRESSES.LENDER, provider),
+                'swivelAddr',
+                '0xswivelAddr',
+                callOverrides,
+            );
         });
     });
 
     suite('pendleAddr', () => {
 
-        const expected = '0xpendleAddr';
+        test('unwraps result and accepts transaction overrides', async () => {
 
-        const overrides: CallOverrides = {
-            gasLimit: '1000',
-            from: '0xfrom',
-            nonce: 1,
-        };
-
-        test('unwraps result', async () => {
-
-            const lender = new Lender(ADDRESSES.LENDER, provider);
-
-            const pendleAddr = mockMethod<string>(lender, 'pendleAddr');
-            pendleAddr.resolves([expected]);
-
-            const result = await lender.pendleAddr();
-
-            assert.strictEqual(result, expected);
-
-            const args = pendleAddr.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, {});
-        });
-
-        test('accepts transaction overrides', async () => {
-
-            const lender = new Lender(ADDRESSES.LENDER, provider);
-
-            const pendleAddr = mockMethod<string>(lender, 'pendleAddr');
-            pendleAddr.resolves([expected]);
-
-            const result = await lender.pendleAddr(overrides);
-
-            assert.strictEqual(result, expected);
-
-            const args = pendleAddr.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, overrides);
+            await assertGetter(
+                new Lender(ADDRESSES.LENDER, provider),
+                'pendleAddr',
+                '0xpendleAddr',
+                callOverrides,
+            );
         });
     });
 
     suite('tempusAddr', () => {
 
-        const expected = '0xtempusAddr';
+        test('unwraps result and accepts transaction overrides', async () => {
 
-        const overrides: CallOverrides = {
-            gasLimit: '1000',
-            from: '0xfrom',
-            nonce: 1,
-        };
-
-        test('unwraps result', async () => {
-
-            const lender = new Lender(ADDRESSES.LENDER, provider);
-
-            const tempusAddr = mockMethod<string>(lender, 'tempusAddr');
-            tempusAddr.resolves([expected]);
-
-            const result = await lender.tempusAddr();
-
-            assert.strictEqual(result, expected);
-
-            const args = tempusAddr.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, {});
-        });
-
-        test('accepts transaction overrides', async () => {
-
-            const lender = new Lender(ADDRESSES.LENDER, provider);
-
-            const tempusAddr = mockMethod<string>(lender, 'tempusAddr');
-            tempusAddr.resolves([expected]);
-
-            const result = await lender.tempusAddr(overrides);
-
-            assert.strictEqual(result, expected);
-
-            const args = tempusAddr.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, overrides);
+            await assertGetter(
+                new Lender(ADDRESSES.LENDER, provider),
+                'tempusAddr',
+                '0xtempusAddr',
+                callOverrides,
+            );
         });
     });
 
     suite('feenominator', () => {
 
         const expected = '1000';
-
-        const overrides: CallOverrides = {
-            gasLimit: '1000',
-            from: '0xfrom',
-            nonce: 1,
-        };
 
         test('unwraps and converts result', async () => {
 
@@ -354,7 +162,7 @@ suite('lender', () => {
             const feenominator = mockMethod<BigNumber>(lender, 'feenominator');
             feenominator.resolves([BigNumber.from(expected)]);
 
-            const result = await lender.feenominator(overrides);
+            const result = await lender.feenominator(callOverrides);
 
             assert.strictEqual(result, expected);
 
@@ -364,7 +172,7 @@ suite('lender', () => {
 
             const [passedOverrides] = args;
 
-            assert.deepStrictEqual(passedOverrides, overrides);
+            assert.deepStrictEqual(passedOverrides, callOverrides);
         });
     });
 
@@ -372,12 +180,6 @@ suite('lender', () => {
 
         const underlying = '0xunderlying';
         const expected = '0';
-
-        const overrides: CallOverrides = {
-            gasLimit: '1000',
-            from: '0xfrom',
-            nonce: 1,
-        };
 
         test('unwraps and converts result', async () => {
 
@@ -411,7 +213,7 @@ suite('lender', () => {
             const fees = mockMethod<BigNumber>(lender, 'fees');
             fees.resolves([BigNumber.from(expected)]);
 
-            const result = await lender.fees(underlying, overrides);
+            const result = await lender.fees(underlying, callOverrides);
 
             assert.strictEqual(result, expected);
 
@@ -422,7 +224,7 @@ suite('lender', () => {
             const [passedUnderlying, passedOverrides] = args;
 
             assert.strictEqual(passedUnderlying, underlying);
-            assert.deepStrictEqual(passedOverrides, overrides);
+            assert.deepStrictEqual(passedOverrides, callOverrides);
         });
     });
 
@@ -463,7 +265,7 @@ suite('lender', () => {
             assert.deepStrictEqual(passedOverrides, {});
         });
 
-        test('accepts overrides', async () => {
+        test('accepts transaction overrides', async () => {
 
             const lender = new Lender(ADDRESSES.LENDER, signer);
 

--- a/test/marketplace.spec.ts
+++ b/test/marketplace.spec.ts
@@ -3,9 +3,15 @@ import { Provider } from '@ethersproject/abstract-provider';
 import { BigNumber, CallOverrides, getDefaultProvider, providers } from 'ethers';
 import { suite, suiteSetup, test } from 'mocha';
 import { MarketPlace, Principals } from '../src/index.js';
-import { ADDRESSES, mockMethod } from './helpers/index.js';
+import { ADDRESSES, assertGetter, mockMethod } from './helpers/index.js';
 
 suite('marketplace', () => {
+
+    const overrides: CallOverrides = {
+        gasLimit: '1000',
+        from: '0xfrom',
+        nonce: 1,
+    };
 
     let provider: Provider;
 
@@ -51,107 +57,27 @@ suite('marketplace', () => {
 
     suite('admin', () => {
 
-        const expected = '0xadmin';
+        test('unwraps result and accepts transaction overrides', async () => {
 
-        const overrides: CallOverrides = {
-            gasLimit: '1000',
-            from: '0xfrom',
-            nonce: 1,
-        };
-
-        test('unwraps result', async () => {
-
-            const marketplace = new MarketPlace(ADDRESSES.MARKETPLACE, provider);
-
-            // mock the MarketPlace contract's `admin` method and tell it to resolve with a typed `Result`
-            // mock will throw if 'admin' doesn't exist on the contract, so tests will fail if it's removed from the abi
-            const admin = mockMethod<string>(marketplace, 'admin');
-            admin.resolves([expected]);
-
-            const result = await marketplace.admin();
-
-            assert.strictEqual(result, expected);
-
-            const args = admin.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, {});
-        });
-
-        test('accepts transaction overrides', async () => {
-
-            const marketplace = new MarketPlace(ADDRESSES.MARKETPLACE, provider);
-
-            // mock the MarketPlace contract's `admin` method and tell it to resolve with a typed `Result`
-            // mock will throw if 'admin' doesn't exist on the contract, so tests will fail if it's removed from the abi
-            const admin = mockMethod<string>(marketplace, 'admin');
-            admin.resolves([expected]);
-
-            const result = await marketplace.admin(overrides);
-
-            assert.strictEqual(result, expected);
-
-            const args = admin.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, overrides);
+            await assertGetter(
+                new MarketPlace(ADDRESSES.MARKETPLACE, provider),
+                'admin',
+                '0xadmin',
+                overrides,
+            );
         });
     });
 
     suite('redeemer', () => {
 
-        const expected = '0xredeemer';
+        test('unwraps result and accepts transaction overrides', async () => {
 
-        const overrides: CallOverrides = {
-            gasLimit: '1000',
-            from: '0xfrom',
-            nonce: 1,
-        };
-
-        test('unwraps result', async () => {
-
-            const marketplace = new MarketPlace(ADDRESSES.MARKETPLACE, provider);
-
-            const redeemer = mockMethod<string>(marketplace, 'redeemer');
-            redeemer.resolves([expected]);
-
-            const result = await marketplace.redeemer();
-
-            assert.strictEqual(result, expected);
-
-            const args = redeemer.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, {});
-        });
-
-        test('accepts transaction overrides', async () => {
-
-            const marketplace = new MarketPlace(ADDRESSES.MARKETPLACE, provider);
-
-            const redeemer = mockMethod<string>(marketplace, 'redeemer');
-            redeemer.resolves([expected]);
-
-            const result = await marketplace.redeemer(overrides);
-
-            assert.strictEqual(result, expected);
-
-            const args = redeemer.getCall(0).args;
-
-            assert.strictEqual(args.length, 1);
-
-            const [passedOverrides] = args;
-
-            assert.deepStrictEqual(passedOverrides, overrides);
+            await assertGetter(
+                new MarketPlace(ADDRESSES.MARKETPLACE, provider),
+                'redeemer',
+                '0xredeemer',
+                overrides,
+            );
         });
     });
 
@@ -160,12 +86,6 @@ suite('marketplace', () => {
         const underlying = '0xunderlying';
         const maturity = '12345678';
         const principal = Principals.Swivel;
-
-        const overrides: CallOverrides = {
-            gasLimit: '1000',
-            from: '0xfrom',
-            nonce: 1,
-        };
 
         const expected = '0xswivel';
 


### PR DESCRIPTION
use test helper for asserting contract getters;
remove unused `Markets` type;
fix import path in `redeemer.ts`;

fixes #1